### PR TITLE
Update wrap.js

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -92,8 +92,8 @@ function wrapWithShitLoadsOfTryCatchBlocks(content, ops) {
 	});
 
 	//next we need to parse a try-catch block. this wraps around the function body. 
-	tryCatchAst = traverse(parse('try { } catch(e){ throw e; }'), [], function(x) {
-
+	tryCatchAst = traverse(parse('try { } catch(e){ catchall.error(e); throw e; }'), [], function(x) {
+		
 		return x[0] == 'try';
 
 	}).pop();


### PR DESCRIPTION
catchall.error should be called in catch block (was removed in commit 564f8e2ee65e6f9681bf975fe023750f80853a7a maybe by accident?)
