### PR TITLE
Update cache.js

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,4 +1,4 @@
-var catchallDir = '/usr/local/etc/catchall',
+var catchallDir = '.catchall',
 cacheDir        = catchallDir + "/cache";
 
 var cfg         = require('yaconfig').file(catchallDir + "/cached.json"),


### PR DESCRIPTION
Several reasons:
-Doesn't work on Windows
-Project specific cache
-Usually normal users don't have write access to /usr/local/etc
